### PR TITLE
Add redirect to GTNH spreadsheet

### DIFF
--- a/spreadsheet.html
+++ b/spreadsheet.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to GTNH spreadsheet on Google Sheets...</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=https://docs.google.com/spreadsheets/d/1EIZtJU5eBbnUlrg7fD_ZyIzsr9sn4l4no9ek6M_iSVM/" />
+  </head>
+  <body>
+    <p>Redirecting to Google Sheets...</p>
+    <p><a href="https://docs.google.com/spreadsheets/d/1EIZtJU5eBbnUlrg7fD_ZyIzsr9sn4l4no9ek6M_iSVM/">Click here</a> if you are not automatically redirected.</p>
+  </body>
+</html>


### PR DESCRIPTION
Adds a redirect to the spreadsheet so that we don't have to rely on third-party link shorteners.